### PR TITLE
🔧 Issue templates: Add default template for Fedora

### DIFF
--- a/.github/ISSUE_TEMPLATE/fedora.md
+++ b/.github/ISSUE_TEMPLATE/fedora.md
@@ -1,0 +1,28 @@
+---
+name: Fedora Project
+about: Default issue template for Fedora workstreams.
+title: ''
+labels: PROJECT::Fedora
+assignees: jwflory
+
+---
+
+# Summary
+<!-- Describe the request in one sentence. -->
+
+
+
+# Background
+<!-- Share context to why this request is important or why it should be completed. -->
+
+
+
+# Details
+<!-- Help us understand how to complete the request. Be specific. Are there clear next steps to take? -->
+
+
+
+# Outcome
+<!-- Describe the impact of this request to Fedora in one sentence. -->
+
+


### PR DESCRIPTION
This commit introduces a new default issue template for Fedora. This integrates the typical format that I use for issues that helps me frame the context for a task. It also uses the Fedora issue label and assigns me as the default assignee.

This prefaces the creation of new issues in this repository for Fedora.